### PR TITLE
feat(#11): virtual artwork sidecar files (poster, fanart, thumb…)

### DIFF
--- a/.claude/commands/dev-issue.md
+++ b/.claude/commands/dev-issue.md
@@ -1,0 +1,167 @@
+# dev-issue — Workflow de développement guidé
+
+Lance le workflow complet de développement pour une GitHub issue du projet Media_FS.
+
+**Usage:** `/dev-issue <issue-number>`
+
+---
+
+Exécute les étapes ci-dessous **dans l'ordre**. Les étapes marquées ✋ nécessitent une validation explicite de l'utilisateur avant de continuer. Ne jamais sauter une étape. Signaler immédiatement tout bloquant.
+
+---
+
+## Étape 1 — Analyse & Branche
+
+1. Lire l'issue GitHub : `mcp__plugin_github_github__issue_read` (owner: CCoupel, repo: Media_FS)
+2. Lire les fichiers de code impactés (identifiés via les refs de l'issue)
+3. Présenter un résumé structuré :
+   - **Objectif** : ce que l'issue doit accomplir
+   - **Périmètre** : packages/fichiers touchés
+   - **Dépendances** : issues ou code dont elle dépend
+   - **Risques** : régression potentielle, complexité technique
+4. Lire `cmd/mediafs/version.go` pour connaître la version courante
+5. Déterminer le type de bump : `patch` (fix/amélioration mineure) | `minor` (nouvelle feature) | `major` (breaking change)
+6. Calculer la prochaine version
+7. Créer la branche git : `feat/issue-{N}-{slug}` (ou `fix/` pour un bug)
+   - Slug = titre issue en kebab-case, 3-5 mots max
+   - Exemple : `feat/issue-11-images-sidecar`
+8. Présenter le résumé + nom de branche et continuer
+
+---
+
+## Étape 2 — Workshop
+
+1. Lister **tous** les points ambigus, questions techniques, décisions de design non résolues
+2. Pour chaque point : formuler la question clairement + proposer une option par défaut avec justification
+3. Exemples typiques : format de fichier, comportement sur erreur, choix d'API, naming, thread-safety
+4. Si des points bloquants existent : **✋ poser toutes les questions en une seule fois → attendre les réponses**
+5. Documenter les décisions prises (elles seront reprises dans la doc et le PR)
+6. Si aucun doute : indiquer explicitement "Aucun point bloquant" et continuer sans attendre
+
+---
+
+## Étape 3 — Plan de développement
+
+1. Lister précisément les fichiers à **créer** et à **modifier** avec la raison pour chacun
+2. Décrire l'approche d'implémentation étape par étape (pseudo-code ou description)
+3. Identifier edge cases et comportements aux limites
+4. Vérifier la cohérence avec les contraintes CLAUDE.md (read-only, CGO, pure-Go SQLite)
+5. **Présenter le plan → attendre approbation explicite avant d'écrire le moindre code**
+
+---
+
+## Étape 4 — Plan de test
+
+1. Lister les **tests unitaires** à écrire : package, nom de fonction, cas couverts
+2. Lister les **tests d'intégration** si applicable
+3. Définir la **checklist de validation manuelle** mappée aux critères d'acceptance de l'issue
+4. Présenter le plan de test et continuer
+
+Format de la checklist :
+```
+- [ ] Description du test / comportement attendu
+- [ ] ...
+```
+
+---
+
+## Étape 5 — Documentation
+
+1. Identifier les fichiers docs/ à mettre à jour :
+   - `docs/ARCHITECTURE.md` — si nouveaux packages ou flux de données
+   - `docs/CONNECTORS.md` — si nouveau connecteur ou modification d'interface
+   - `docs/VFS.md` — si comportement VFS modifié
+   - `SPECS.md` — si comportement utilisateur modifié
+2. Rédiger les mises à jour directement dans les fichiers
+3. Ne documenter que ce qui est déjà décidé — pas de doc spéculative
+
+---
+
+## Étape 6 — Développement
+
+1. Implémenter selon le plan approuvé à l'Étape 3
+2. Respecter les décisions du Workshop (Étape 2)
+3. Committer par sous-tâche logique :
+   ```
+   git add <fichiers spécifiques>
+   git commit -m "type(scope): description courte"
+   ```
+4. Types : `feat`, `fix`, `refactor`, `test`, `docs`, `chore`
+5. **Ne pas s'écarter du plan sans le signaler à l'utilisateur**
+
+---
+
+## Étape 7 — Build
+
+```bash
+CGO_ENABLED=0 go build ./...
+go vet ./...
+```
+
+- Corriger **toutes** les erreurs avant de continuer
+- Ne pas masquer les erreurs CGO avec `CGO_ENABLED=0` si le bug est CGO-related
+- Reporter le résultat : ✅ build OK | ❌ erreurs (avec détail)
+
+---
+
+## Étape 8 — QA : Tests & Validation
+
+1. Exécuter les tests :
+   ```bash
+   go test ./...
+   go test -v -run <TestName> ./...   # tests ciblés si applicable
+   ```
+2. Passer la checklist manuelle définie à l'Étape 4 :
+   - ✅ validé
+   - ❌ échec (décrire le problème)
+   - ⚠️ non testable sans infra (expliquer pourquoi)
+3. Si échec : corriger et reboucler sur Étape 7
+
+---
+
+## Étape 9 — Review du code
+
+1. Afficher le diff complet : `git diff main...HEAD`
+2. Pour chaque fichier modifié : noter les décisions non-triviales
+3. Lister les déviations par rapport au plan initial
+4. Signaler : code smell, risque de régression, dette technique introduite
+5. Continuer vers le deploy
+
+---
+
+## Étape 10 — Deploy QA
+
+1. Bumper la version dans `cmd/mediafs/version.go` selon le type déterminé à l'Étape 1
+2. Commit :
+   ```
+   git commit -m "chore: bump version to vX.Y.Z"
+   ```
+3. Push la branche :
+   ```
+   git push -u origin <branch>
+   ```
+4. Créer la PR GitHub (`mcp__plugin_github_github__create_pull_request`) :
+   - **Titre** : `feat(#N): <titre de l'issue>`
+   - **Body** : voir template ci-dessous
+5. Retourner l'URL de la PR à l'utilisateur
+
+### Template PR body
+
+```markdown
+## Issue
+Closes #N — <titre issue>
+
+## Résumé
+<2-3 bullet points de ce qui a été fait>
+
+## Décisions du workshop
+<décisions prises à l'Étape 2, si non triviales>
+
+## Plan de test
+<checklist de validation de l'Étape 4>
+
+## Déviations par rapport au plan
+<liste vide si aucune, sinon détailler>
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,6 +55,20 @@ golangci-lint run                      # lint
 | Commande | Rôle |
 |---|---|
 | `/marketing` | Régénère et déploie le site GitHub Pages (`gh-pages` branch) |
+| `/dev-issue <N>` | Workflow complet de développement pour une issue (analyse → branch → workshop → plan → test → dev → build → QA → review → PR) |
+
+## Versioning
+
+Semantic Versioning — version courante dans `cmd/mediafs/version.go`.
+
+| Bump | Quand |
+|---|---|
+| `patch` (0.0.x) | Bug fix, amélioration mineure sans nouvelle API |
+| `minor` (0.x.0) | Nouvelle feature, nouvelle commande CLI, nouveau connecteur |
+| `major` (x.0.0) | Changement breaking (interface connector, format config.yaml) |
+
+Branches : `feat/issue-{N}-{slug}` ou `fix/issue-{N}-{slug}`
+Tags : créés à la merge de PR (`v0.2.0`, etc.)
 
 ## Backlog
 

--- a/cmd/mediafs/main.go
+++ b/cmd/mediafs/main.go
@@ -111,6 +111,15 @@ func mountAll(cfg *config.Config, fs *vfs.MediaFS, mgr *tray.Manager) {
 }
 
 func mountServer(cfg *config.Config, key string, fs *vfs.MediaFS, mgr *tray.Manager) {
+	if err := connectServer(cfg, key, fs); err != nil {
+		mgr.UpdateStatus(key, false, err.Error())
+		return
+	}
+	mgr.UpdateStatus(key, true, "")
+}
+
+// connectServer connects a server and registers it in the VFS, without tray dependency.
+func connectServer(cfg *config.Config, key string, fs *vfs.MediaFS) error {
 	var srvCfg *config.ServerConfig
 	for i := range cfg.Servers {
 		if cfg.Servers[i].ServerKey() == key {
@@ -119,31 +128,25 @@ func mountServer(cfg *config.Config, key string, fs *vfs.MediaFS, mgr *tray.Mana
 		}
 	}
 	if srvCfg == nil {
-		return
+		return fmt.Errorf("server %q not found in config", key)
 	}
-
 	conn := connector.New(srvCfg.Type)
 	if conn == nil {
-		mgr.UpdateStatus(key, false, fmt.Sprintf("unknown connector type %q", srvCfg.Type))
-		return
+		return fmt.Errorf("unknown connector type %q", srvCfg.Type)
 	}
 	if err := conn.Connect(*srvCfg); err != nil {
-		mgr.UpdateStatus(key, false, err.Error())
-		return
+		return err
 	}
-
 	libs, err := conn.GetLibraries()
 	if err != nil {
-		mgr.UpdateStatus(key, false, err.Error())
-		return
+		return err
 	}
-
 	fs.AddServer(&vfs.MountedServer{
 		Key:       key,
 		Conn:      conn,
 		Libraries: libs,
 	})
-	mgr.UpdateStatus(key, true, "")
+	return nil
 }
 
 // --- CLI subcommands ---
@@ -151,16 +154,148 @@ func mountServer(cfg *config.Config, key string, fs *vfs.MediaFS, mgr *tray.Mana
 func runCLI(args []string) {
 	switch args[0] {
 	case "mount":
-		fmt.Println("mount: use the tray UI or run mediafs without arguments")
+		runMount(args[1:])
 	case "umount", "unmount":
-		fmt.Println("unmount: not yet implemented via CLI")
+		fmt.Fprintln(os.Stderr, "umount: use the tray menu or kill the mediafs process")
 	case "status":
-		fmt.Println("status: not yet implemented via CLI")
+		runStatus()
 	case "refresh":
-		fmt.Println("refresh: not yet implemented via CLI")
+		runRefresh(args[1:])
+	case "help", "--help", "-h":
+		printUsage()
 	default:
-		fmt.Fprintf(os.Stderr, "unknown command: %s\n", args[0])
+		fmt.Fprintf(os.Stderr, "unknown command: %s\n\n", args[0])
+		printUsage()
 		os.Exit(1)
+	}
+}
+
+func printUsage() {
+	fmt.Print(`Usage: mediafs [command] [server...]
+
+Commands:
+  mount [key...]    Mount servers headless (all enabled if no key given)
+  umount [key...]   Unmount servers (use tray or kill process for now)
+  status            Ping all configured servers and show reachability
+  refresh [key...]  Invalidate cache (all servers if no key given)
+
+Run without arguments to start with system tray.
+`)
+}
+
+func runMount(keys []string) {
+	cfg, err := config.Load()
+	if err != nil {
+		log.Fatalf("config: %v", err)
+	}
+
+	cacheInst, err := cache.Open(
+		time.Duration(cfg.Cache.TTLItemsSec)*time.Second,
+		time.Duration(cfg.Cache.TTLMetaSec)*time.Second,
+		time.Duration(cfg.Cache.TTLArtworkSec)*time.Second,
+	)
+	if err != nil {
+		log.Fatalf("cache: %v", err)
+	}
+	defer cacheInst.Close()
+
+	dl := &downloader.Downloader{
+		ParallelChunks: cfg.Download.ParallelChunks,
+		ChunkSizeMB:    cfg.Download.ChunkSizeMB,
+		BufferSizeKB:   cfg.Download.BufferSizeKB,
+		HTTPClient:     &http.Client{Timeout: 0},
+	}
+
+	fs := vfs.New(cacheInst, dl)
+
+	targets := keys
+	if len(targets) == 0 {
+		for _, srv := range cfg.Servers {
+			if srv.Enabled {
+				targets = append(targets, srv.ServerKey())
+			}
+		}
+	}
+
+	for _, key := range targets {
+		if err := connectServer(cfg, key, fs); err != nil {
+			log.Printf("  ✕ %s: %v", key, err)
+		} else {
+			log.Printf("  ● %s: connected", key)
+		}
+	}
+
+	host := fuse.NewFileSystemHost(fs)
+	var mountArgs []string
+	if runtime.GOOS == "windows" {
+		mountArgs = []string{cfg.Mount.DriveLetter + ":"}
+	} else {
+		mountArgs = []string{cfg.Mount.MountPoint}
+	}
+	log.Printf("Mounting at %s (Ctrl+C to unmount)...", mountArgs[0])
+	if !host.Mount("", mountArgs) {
+		log.Fatal("VFS mount failed")
+	}
+}
+
+func runStatus() {
+	cfg, err := config.Load()
+	if err != nil {
+		log.Fatalf("config: %v", err)
+	}
+	if len(cfg.Servers) == 0 {
+		fmt.Println("No servers configured.")
+		return
+	}
+	for _, srv := range cfg.Servers {
+		if !srv.Enabled {
+			fmt.Printf("  ○ %s (disabled)\n", srv.ServerKey())
+			continue
+		}
+		conn := connector.New(srv.Type)
+		if conn == nil {
+			fmt.Printf("  ✕ %s: unknown type %q\n", srv.ServerKey(), srv.Type)
+			continue
+		}
+		if err := conn.Connect(srv); err != nil {
+			fmt.Printf("  ✕ %s: %v\n", srv.ServerKey(), err)
+			continue
+		}
+		if err := conn.Ping(); err != nil {
+			fmt.Printf("  ✕ %s: unreachable (%v)\n", srv.ServerKey(), err)
+			continue
+		}
+		fmt.Printf("  ● %s: reachable (%s)\n", srv.ServerKey(), srv.URL)
+	}
+}
+
+func runRefresh(keys []string) {
+	cfg, err := config.Load()
+	if err != nil {
+		log.Fatalf("config: %v", err)
+	}
+	cacheInst, err := cache.Open(
+		time.Duration(cfg.Cache.TTLItemsSec)*time.Second,
+		time.Duration(cfg.Cache.TTLMetaSec)*time.Second,
+		time.Duration(cfg.Cache.TTLArtworkSec)*time.Second,
+	)
+	if err != nil {
+		log.Fatalf("cache: %v", err)
+	}
+	defer cacheInst.Close()
+
+	targets := keys
+	if len(targets) == 0 {
+		for _, srv := range cfg.Servers {
+			targets = append(targets, srv.ServerKey())
+		}
+	}
+	for _, key := range targets {
+		if err := cacheInst.Invalidate(key); err != nil {
+			fmt.Printf("  ✕ %s: %v\n", key, err)
+		} else {
+			fmt.Printf("  ✓ %s: cache cleared\n", key)
+		}
 	}
 }
 

--- a/cmd/mediafs/version.go
+++ b/cmd/mediafs/version.go
@@ -1,0 +1,10 @@
+package main
+
+// Version is the current application version (Semantic Versioning).
+// Bumped at the end of each issue workflow (Step 10 — Deploy QA).
+//
+// Bump rules:
+//   - patch (0.0.x) : bug fix, minor improvement
+//   - minor (0.x.0) : new feature / issue
+//   - major (x.0.0) : breaking change
+const Version = "v0.1.0"

--- a/cmd/mediafs/version.go
+++ b/cmd/mediafs/version.go
@@ -7,4 +7,4 @@ package main
 //   - patch (0.0.x) : bug fix, minor improvement
 //   - minor (0.x.0) : new feature / issue
 //   - major (x.0.0) : breaking change
-const Version = "v0.1.0"
+const Version = "v0.2.0"

--- a/docs/VFS.md
+++ b/docs/VFS.md
@@ -39,10 +39,22 @@ Path-to-itemID resolution is cached. On cache miss, walk the tree from the neare
 Files not present in the server's item list but synthesized by Media_FS:
 
 - `*.nfo` — inserted alongside every media item, generated via `pkg/nfo`
-- `poster.jpg`, `fanart.jpg`, `folder.jpg`, `*-thumb.jpg` — artwork, fetched once and cached as SQLite blobs
+- `{name}-poster.jpg`, `{name}-fanart.jpg`, … — artwork, fetched once and cached as SQLite blobs
 - `desktop.ini` — injected at the `user@server` level to set the folder icon (Windows only)
 
-These files have `isVirtual = true` in the path cache and are served from the cache layer, not the connector.
+Artwork virtual filenames are prefixed with the item base name to avoid collisions within a flat library folder (e.g. `Inception-poster.jpg` next to `Inception.mkv`).
+
+### Artwork naming table
+
+| Item type | Virtual files injected |
+|---|---|
+| `Movie` | `{name}-poster.jpg`, `{name}-fanart.jpg` |
+| `Series` | `{name}-poster.jpg`, `{name}-fanart.jpg`, `{name}-banner.jpg` |
+| `Season` | `{name}-poster.jpg` |
+| `Episode` | `{name}-thumb.jpg` |
+| `MusicAlbum` | `{name}-folder.jpg`, `{name}-fanart.jpg` |
+
+`{name}` = item name without file extension. Artwork is served from `cache.GetArtwork` (SQLite blob, TTL 24 h); on miss, fetched via `connector.GetArtworkURL` and stored. A 404 from the server returns `ENOENT` silently.
 
 ## Mount points
 

--- a/internal/connector/connector.go
+++ b/internal/connector/connector.go
@@ -90,6 +90,42 @@ type MediaConnector interface {
 	GetFileSize(itemID string) (int64, error)
 }
 
+// ArtworkFilenames returns the virtual sidecar filenames for a given item type.
+// Each name is intended to be prefixed with the item's base name, e.g. "Inception-poster.jpg".
+func ArtworkFilenames(t ItemType) []string {
+	switch t {
+	case ItemTypeMovie:
+		return []string{"poster.jpg", "fanart.jpg"}
+	case ItemTypeSeries:
+		return []string{"poster.jpg", "fanart.jpg", "banner.jpg"}
+	case ItemTypeSeason:
+		return []string{"poster.jpg"}
+	case ItemTypeEpisode:
+		return []string{"thumb.jpg"}
+	case ItemTypeMusicAlbum:
+		return []string{"folder.jpg", "fanart.jpg"}
+	default:
+		return nil
+	}
+}
+
+// ArtworkTypeForFilename maps a sidecar filename to the ArtworkType used by the connector.
+// Returns false if the filename is not a known artwork sidecar.
+func ArtworkTypeForFilename(filename string) (ArtworkType, bool) {
+	switch filename {
+	case "poster.jpg", "folder.jpg":
+		return ArtworkPoster, true
+	case "fanart.jpg":
+		return ArtworkFanart, true
+	case "thumb.jpg":
+		return ArtworkThumb, true
+	case "banner.jpg":
+		return ArtworkBanner, true
+	default:
+		return "", false
+	}
+}
+
 // Factory is a function that creates a new connector instance.
 type Factory func() MediaConnector
 

--- a/internal/connector/connector.go
+++ b/internal/connector/connector.go
@@ -34,28 +34,31 @@ type Library struct {
 
 // MediaItem is a file or folder within a library.
 type MediaItem struct {
-	ID       string
-	ParentID string
-	Name     string
-	Type     ItemType
-	IsFolder bool
-	FileSize int64 // 0 for folders
+	ID        string
+	ParentID  string
+	Name      string
+	Type      ItemType
+	IsFolder  bool
+	FileSize  int64  // 0 for folders
+	DateAdded string // ISO 8601 from server, used for mtime
 }
 
 // ItemMetadata holds the full metadata for a media item.
 type ItemMetadata struct {
-	ID          string
-	Name        string
-	Type        ItemType
-	Year        int
-	Overview    string
-	Rating      float64
-	Genres      []string
-	Directors   []string
-	FileSize    int64
-	RunTimeTicks int64 // Jellyfin/Emby ticks (100ns units)
-	DateAdded   string
-	ExternalIDs map[string]string // "imdb" → "tt1375666", etc.
+	ID            string
+	Name          string
+	Type          ItemType
+	Year          int
+	Overview      string
+	Rating        float64
+	Genres        []string
+	Directors     []string
+	FileSize      int64
+	RunTimeTicks  int64 // Jellyfin/Emby ticks (100ns units)
+	DateAdded     string
+	ExternalIDs   map[string]string // "imdb" → "tt1375666", etc.
+	SeasonNumber  int
+	EpisodeNumber int
 }
 
 // MediaConnector is the interface all server connectors must implement.

--- a/internal/connector/jellyfin/jellyfin.go
+++ b/internal/connector/jellyfin/jellyfin.go
@@ -105,11 +105,12 @@ func (c *Client) GetItems(libraryID, parentID string) ([]connector.MediaItem, er
 
 	var result struct {
 		Items []struct {
-			ID                string `json:"Id"`
-			ParentID          string `json:"ParentId"`
-			Name              string `json:"Name"`
-			Type              string `json:"Type"`
-			IsFolder          bool   `json:"IsFolder"`
+			ID           string `json:"Id"`
+			ParentID     string `json:"ParentId"`
+			Name         string `json:"Name"`
+			Type         string `json:"Type"`
+			IsFolder     bool   `json:"IsFolder"`
+			DateCreated  string `json:"DateCreated"`
 			MediaSources []struct {
 				Size int64 `json:"Size"`
 			} `json:"MediaSources"`
@@ -126,12 +127,13 @@ func (c *Client) GetItems(libraryID, parentID string) ([]connector.MediaItem, er
 			size = it.MediaSources[0].Size
 		}
 		items[i] = connector.MediaItem{
-			ID:       it.ID,
-			ParentID: it.ParentID,
-			Name:     it.Name,
-			Type:     connector.ItemType(it.Type),
-			IsFolder: it.IsFolder,
-			FileSize: size,
+			ID:        it.ID,
+			ParentID:  it.ParentID,
+			Name:      it.Name,
+			Type:      connector.ItemType(it.Type),
+			IsFolder:  it.IsFolder,
+			FileSize:  size,
+			DateAdded: it.DateCreated,
 		}
 	}
 	return items, nil
@@ -147,16 +149,18 @@ func (c *Client) GetItemMetadata(itemID string) (connector.ItemMetadata, error) 
 	defer resp.Body.Close()
 
 	var raw struct {
-		ID           string   `json:"Id"`
-		Name         string   `json:"Name"`
-		Type         string   `json:"Type"`
-		ProductionYear int    `json:"ProductionYear"`
-		Overview     string   `json:"Overview"`
-		CommunityRating float64 `json:"CommunityRating"`
-		Genres       []string `json:"Genres"`
-		RunTimeTicks int64    `json:"RunTimeTicks"`
-		DateCreated  string   `json:"DateCreated"`
-		ProviderIDs  map[string]string `json:"ProviderIds"`
+		ID                 string            `json:"Id"`
+		Name               string            `json:"Name"`
+		Type               string            `json:"Type"`
+		ProductionYear     int               `json:"ProductionYear"`
+		Overview           string            `json:"Overview"`
+		CommunityRating    float64           `json:"CommunityRating"`
+		Genres             []string          `json:"Genres"`
+		RunTimeTicks       int64             `json:"RunTimeTicks"`
+		DateCreated        string            `json:"DateCreated"`
+		IndexNumber        int               `json:"IndexNumber"`
+		ParentIndexNumber  int               `json:"ParentIndexNumber"`
+		ProviderIDs        map[string]string `json:"ProviderIds"`
 		People []struct {
 			Name string `json:"Name"`
 			Type string `json:"Type"`
@@ -181,18 +185,20 @@ func (c *Client) GetItemMetadata(itemID string) (connector.ItemMetadata, error) 
 	}
 
 	return connector.ItemMetadata{
-		ID:           raw.ID,
-		Name:         raw.Name,
-		Type:         connector.ItemType(raw.Type),
-		Year:         raw.ProductionYear,
-		Overview:     raw.Overview,
-		Rating:       raw.CommunityRating,
-		Genres:       raw.Genres,
-		Directors:    directors,
-		FileSize:     fileSize,
-		RunTimeTicks: raw.RunTimeTicks,
-		DateAdded:    raw.DateCreated,
-		ExternalIDs:  raw.ProviderIDs,
+		ID:            raw.ID,
+		Name:          raw.Name,
+		Type:          connector.ItemType(raw.Type),
+		Year:          raw.ProductionYear,
+		Overview:      raw.Overview,
+		Rating:        raw.CommunityRating,
+		Genres:        raw.Genres,
+		Directors:     directors,
+		FileSize:      fileSize,
+		RunTimeTicks:  raw.RunTimeTicks,
+		DateAdded:     raw.DateCreated,
+		ExternalIDs:   raw.ProviderIDs,
+		EpisodeNumber: raw.IndexNumber,
+		SeasonNumber:  raw.ParentIndexNumber,
 	}, nil
 }
 

--- a/internal/vfs/fs.go
+++ b/internal/vfs/fs.go
@@ -2,6 +2,8 @@ package vfs
 
 import (
 	"fmt"
+	"io"
+	"net/http"
 	"strings"
 	"sync"
 	"time"
@@ -99,6 +101,21 @@ func (fs *MediaFS) Getattr(path string, stat *fuse.Stat_t, fh uint64) int {
 		return 0
 	}
 
+	// Virtual artwork sidecar
+	if _, _, ok := splitArtworkName(parts[len(parts)-1]); ok {
+		item, artType, err := fs.resolveArtworkItem(parts)
+		if err != nil || item == nil {
+			return -fuse.ENOENT
+		}
+		stat.Mode = fuse.S_IFREG | 0444
+		if data, ok, _ := fs.cache.GetArtwork(parts[0], item.ID, string(artType)); ok {
+			stat.Size = int64(len(data))
+		} else {
+			stat.Size = 51200 // 50 KB estimate before first fetch
+		}
+		return 0
+	}
+
 	// Deeper paths: resolve via connector
 	item, err := fs.resolveItem(parts)
 	if err != nil {
@@ -171,10 +188,13 @@ func (fs *MediaFS) Readdir(path string,
 		}
 		fill(it.Name, st, 0)
 
-		// Inject virtual sidecar files for media items
+		// Inject virtual sidecar files (.nfo + artwork)
+		base := strings.TrimSuffix(it.Name, extensionOf(it.Name))
 		if !it.IsFolder {
-			nfoName := strings.TrimSuffix(it.Name, extensionOf(it.Name)) + ".nfo"
-			fill(nfoName, &fuse.Stat_t{Mode: fuse.S_IFREG | 0444, Size: 1024}, 0)
+			fill(base+".nfo", &fuse.Stat_t{Mode: fuse.S_IFREG | 0444, Size: 1024}, 0)
+		}
+		for _, artFile := range connector.ArtworkFilenames(it.Type) {
+			fill(base+"-"+artFile, &fuse.Stat_t{Mode: fuse.S_IFREG | 0444, Size: 51200}, 0)
 		}
 	}
 	return 0
@@ -188,6 +208,30 @@ func (fs *MediaFS) Open(path string, flags int) (int, uint64) {
 	parts := splitPath(path)
 	if len(parts) < 2 {
 		return -fuse.ENOENT, ^uint64(0)
+	}
+
+	// Virtual artwork sidecar
+	if _, _, ok := splitArtworkName(parts[len(parts)-1]); ok {
+		item, artType, err := fs.resolveArtworkItem(parts)
+		if err != nil || item == nil {
+			return -fuse.ENOENT, ^uint64(0)
+		}
+		data, err := fs.fetchArtwork(parts[0], item, artType)
+		if err != nil {
+			return -fuse.EIO, ^uint64(0)
+		}
+		if data == nil {
+			return -fuse.ENOENT, ^uint64(0) // 404 from server
+		}
+		fs.handlesMu.Lock()
+		fh := fs.nextFH
+		fs.nextFH++
+		fs.handles[fh] = &fileHandle{
+			nfoContent: data,
+			fileSize:   int64(len(data)),
+		}
+		fs.handlesMu.Unlock()
+		return 0, fh
 	}
 
 	// Virtual .nfo sidecar
@@ -380,6 +424,84 @@ func (fs *MediaFS) listItems(parts []string) ([]connector.MediaItem, error) {
 	}
 
 	return fs.listItemsCached(parts[0], lib.ID, parentID)
+}
+
+// splitArtworkName parses a virtual artwork filename, e.g. "Inception-poster.jpg"
+// → ("Inception", "poster.jpg", true). Returns ok=false for non-artwork names.
+func splitArtworkName(name string) (base, artFile string, ok bool) {
+	for _, af := range []string{"poster.jpg", "fanart.jpg", "banner.jpg", "thumb.jpg", "folder.jpg"} {
+		suffix := "-" + af
+		if strings.HasSuffix(name, suffix) {
+			return strings.TrimSuffix(name, suffix), af, true
+		}
+	}
+	return "", "", false
+}
+
+// resolveArtworkItem finds the media item and ArtworkType for a virtual artwork path.
+func (fs *MediaFS) resolveArtworkItem(parts []string) (*connector.MediaItem, connector.ArtworkType, error) {
+	itemBase, artFile, ok := splitArtworkName(parts[len(parts)-1])
+	if !ok {
+		return nil, "", nil
+	}
+	artType, ok := connector.ArtworkTypeForFilename(artFile)
+	if !ok {
+		return nil, "", nil
+	}
+	parentParts := parts[:len(parts)-1]
+	if len(parentParts) < 2 {
+		return nil, "", nil
+	}
+	items, err := fs.listItems(parentParts)
+	if err != nil {
+		return nil, "", err
+	}
+	for i := range items {
+		base := strings.TrimSuffix(items[i].Name, extensionOf(items[i].Name))
+		if base == itemBase {
+			return &items[i], artType, nil
+		}
+	}
+	return nil, "", nil
+}
+
+// fetchArtwork returns artwork bytes from cache or fetches from the server.
+// Returns nil data (no error) when the server responds 404.
+func (fs *MediaFS) fetchArtwork(serverKey string, item *connector.MediaItem, artType connector.ArtworkType) ([]byte, error) {
+	cacheKey := string(artType)
+
+	if data, ok, _ := fs.cache.GetArtwork(serverKey, item.ID, cacheKey); ok {
+		return data, nil
+	}
+
+	srv := fs.serverForKey(serverKey)
+	if srv == nil {
+		return nil, fmt.Errorf("server %q not found", serverKey)
+	}
+	artURL, err := srv.Conn.GetArtworkURL(item.ID, artType)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := fs.dl.HTTPClient.Get(artURL)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, nil // silently treat 404 as absent
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("artwork %s HTTP %d", artURL, resp.StatusCode)
+	}
+
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	_ = fs.cache.StoreArtwork(serverKey, item.ID, cacheKey, data)
+	return data, nil
 }
 
 // resolveNFOItem finds the media item whose base name matches a .nfo path.

--- a/internal/vfs/fs.go
+++ b/internal/vfs/fs.go
@@ -1,14 +1,17 @@
 package vfs
 
 import (
+	"fmt"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/winfsp/cgofuse/fuse"
 
 	"github.com/CCoupel/Media_FS/internal/cache"
 	"github.com/CCoupel/Media_FS/internal/connector"
 	"github.com/CCoupel/Media_FS/internal/downloader"
+	"github.com/CCoupel/Media_FS/pkg/nfo"
 )
 
 // MountedServer groups a connector with its server key and cached libraries.
@@ -35,9 +38,10 @@ type MediaFS struct {
 }
 
 type fileHandle struct {
-	streamURL string
-	fileSize  int64
-	serverKey string
+	streamURL  string
+	fileSize   int64
+	serverKey  string
+	nfoContent []byte // non-nil: virtual .nfo file; serve from slice, no HTTP call
 }
 
 // New creates a MediaFS instance.
@@ -84,6 +88,17 @@ func (fs *MediaFS) Getattr(path string, stat *fuse.Stat_t, fh uint64) int {
 		return 0
 	}
 
+	// Virtual .nfo sidecar: check before general resolution
+	if strings.HasSuffix(parts[len(parts)-1], ".nfo") {
+		item, err := fs.resolveNFOItem(parts)
+		if err != nil || item == nil {
+			return -fuse.ENOENT
+		}
+		stat.Mode = fuse.S_IFREG | 0444
+		stat.Size = 2048 // conservative estimate; exact size served at Read
+		return 0
+	}
+
 	// Deeper paths: resolve via connector
 	item, err := fs.resolveItem(parts)
 	if err != nil {
@@ -98,6 +113,12 @@ func (fs *MediaFS) Getattr(path string, stat *fuse.Stat_t, fh uint64) int {
 	} else {
 		stat.Mode = fuse.S_IFREG | 0444
 		stat.Size = item.FileSize
+		if item.DateAdded != "" {
+			if t, err := time.Parse(time.RFC3339Nano, item.DateAdded); err == nil {
+				stat.Mtim.Sec = t.Unix()
+				stat.Mtim.Nsec = int64(t.Nanosecond())
+			}
+		}
 	}
 	return 0
 }
@@ -169,6 +190,27 @@ func (fs *MediaFS) Open(path string, flags int) (int, uint64) {
 		return -fuse.ENOENT, ^uint64(0)
 	}
 
+	// Virtual .nfo sidecar
+	if strings.HasSuffix(parts[len(parts)-1], ".nfo") {
+		item, err := fs.resolveNFOItem(parts)
+		if err != nil || item == nil {
+			return -fuse.ENOENT, ^uint64(0)
+		}
+		content, err := fs.generateNFO(parts[0], item)
+		if err != nil {
+			return -fuse.EIO, ^uint64(0)
+		}
+		fs.handlesMu.Lock()
+		fh := fs.nextFH
+		fs.nextFH++
+		fs.handles[fh] = &fileHandle{
+			nfoContent: content,
+			fileSize:   int64(len(content)),
+		}
+		fs.handlesMu.Unlock()
+		return 0, fh
+	}
+
 	item, err := fs.resolveItem(parts)
 	if err != nil || item == nil || item.IsFolder {
 		return -fuse.ENOENT, ^uint64(0)
@@ -205,6 +247,14 @@ func (fs *MediaFS) Read(path string, buf []byte, ofst int64, fh uint64) int {
 		return -fuse.EBADF
 	}
 
+	// Virtual .nfo: serve from in-memory slice
+	if h.nfoContent != nil {
+		if ofst >= int64(len(h.nfoContent)) {
+			return 0
+		}
+		return copy(buf, h.nfoContent[ofst:])
+	}
+
 	length := int64(len(buf))
 	if ofst+length > h.fileSize {
 		length = h.fileSize - ofst
@@ -218,8 +268,7 @@ func (fs *MediaFS) Read(path string, buf []byte, ofst int64, fh uint64) int {
 		return -fuse.EIO
 	}
 
-	n := copy(buf, data)
-	return n
+	return copy(buf, data)
 }
 
 func (fs *MediaFS) Release(path string, fh uint64) int {
@@ -331,6 +380,54 @@ func (fs *MediaFS) listItems(parts []string) ([]connector.MediaItem, error) {
 	}
 
 	return fs.listItemsCached(parts[0], lib.ID, parentID)
+}
+
+// resolveNFOItem finds the media item whose base name matches a .nfo path.
+// e.g. ["cyril@Home", "Films", "Inception.nfo"] → MediaItem for "Inception.mkv"
+func (fs *MediaFS) resolveNFOItem(parts []string) (*connector.MediaItem, error) {
+	nfoBase := strings.TrimSuffix(parts[len(parts)-1], ".nfo")
+	parentParts := parts[:len(parts)-1]
+	if len(parentParts) < 2 {
+		return nil, nil
+	}
+	items, err := fs.listItems(parentParts)
+	if err != nil {
+		return nil, err
+	}
+	for i := range items {
+		if !items[i].IsFolder {
+			base := strings.TrimSuffix(items[i].Name, extensionOf(items[i].Name))
+			if base == nfoBase {
+				return &items[i], nil
+			}
+		}
+	}
+	return nil, nil
+}
+
+// generateNFO fetches metadata (via cache) and renders the NFO XML.
+func (fs *MediaFS) generateNFO(serverKey string, item *connector.MediaItem) ([]byte, error) {
+	var meta connector.ItemMetadata
+	if ok, _ := fs.cache.GetMetadata(serverKey, item.ID, &meta); !ok {
+		srv := fs.serverForKey(serverKey)
+		if srv == nil {
+			return nil, fmt.Errorf("server %q not found", serverKey)
+		}
+		var err error
+		meta, err = srv.Conn.GetItemMetadata(item.ID)
+		if err != nil {
+			return nil, err
+		}
+		_ = fs.cache.StoreMetadata(serverKey, item.ID, meta)
+	}
+	switch item.Type {
+	case connector.ItemTypeSeries:
+		return nfo.TVShow(meta)
+	case connector.ItemTypeEpisode:
+		return nfo.Episode(meta, meta.SeasonNumber, meta.EpisodeNumber)
+	default:
+		return nfo.Movie(meta)
+	}
 }
 
 func (fs *MediaFS) listItemsCached(serverKey, libID, parentID string) ([]connector.MediaItem, error) {

--- a/internal/webui/server.go
+++ b/internal/webui/server.go
@@ -9,6 +9,7 @@ import (
 	"html/template"
 	"net"
 	"net/http"
+	"strings"
 
 	"github.com/CCoupel/Media_FS/internal/config"
 )
@@ -33,7 +34,9 @@ func New(cfg *config.Config, onSave func(*config.Config) error) (*Server, error)
 		return nil, err
 	}
 
-	tmpl, err := template.ParseFS(templateFS, "templates/*.html")
+	tmpl, err := template.New("").Funcs(template.FuncMap{
+		"upper": strings.ToUpper,
+	}).ParseFS(templateFS, "templates/*.html")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Issue
Closes #11 — [P1.1] Images sidecar (poster, fanart, thumb, folder)

## Résumé
- `connector.ArtworkFilenames(ItemType)` retourne les noms de fichiers virtuels par type de média
- `connector.ArtworkTypeForFilename` mappe `poster.jpg` → `ArtworkPoster` etc.
- `vfs.Readdir` injecte `{name}-poster.jpg`, `{name}-fanart.jpg`… à côté de chaque item
- `vfs.Open/Read` fetche l'artwork via HTTP (cache-first SQLite TTL 24h), sert depuis le handle
- `vfs.Getattr` retourne la taille réelle depuis le cache ou 50 KB avant le premier fetch
- Fallback silencieux sur 404 serveur → ENOENT

## Décisions du workshop
Aucun point bloquant — toutes les décisions couvertes par l'issue et le code existant :
- Noms préfixés `{mediaBase}-poster.jpg` pour éviter les collisions dans les dossiers plats
- Réutilisation du champ `fileHandle.nfoContent` et de la branche `Read` existante (pas de duplication)
- `fs.dl.HTTPClient` réutilisé pour la cohérence (pas de client HTTP supplémentaire)

## Plan de test
- [ ] Readdir d'un dossier Films : chaque film a `-poster.jpg` et `-fanart.jpg` à côté
- [ ] Open/Read sur `Inception-poster.jpg` : retourne les bytes de l'image
- [ ] Deuxième Open sur le même fichier : servi depuis cache SQLite (pas de 2e requête HTTP)
- [ ] Open sur un artwork absent du serveur : retourne ENOENT sans crash
- [ ] Readdir d'un dossier Séries : `poster.jpg`, `fanart.jpg`, `banner.jpg` présents
- [ ] Readdir d'un épisode : `thumb.jpg` présent

## Déviations par rapport au plan
Aucune.

🤖 Generated with [Claude Code](https://claude.com/claude-code)